### PR TITLE
Parse new & old versions of the dispersion report

### DIFF
--- a/srm/__init__.py
+++ b/srm/__init__.py
@@ -2,7 +2,7 @@ import gettext
 
 
 #: Version information (major, minor, revision[, 'dev']).
-version_info = (0, 1, 17)
+version_info = (0, 1, 18)
 #: Version string 'major.minor.revision'.
 version = __version__ = ".".join(map(str, version_info))
 gettext.install('swift-ring-master')

--- a/srm/ringmasterd.py
+++ b/srm/ringmasterd.py
@@ -205,9 +205,12 @@ class RingMasterServer(object):
             self.logger.notice("--> Dispersion report run returned nothing!")
             return False
         self.logger.debug("--> Dispersion info: %s" % result)
-        if result[swift_type]['missing_2'] == 0 and \
-                result[swift_type]['pct_found'] > \
-                self.dispersion_pct[swift_type]:
+        #the dsp report json output has changed a bit so we have to check for all
+        if not result[swift_type].get('missing_2', 0) == 0 and \
+                result[swift_type].get('missing_3', 0) == 0 and \
+                result[swift_type].get('missing_all', 0) == 0:
+            return False
+        if result[swift_type]['pct_found'] > self.dispersion_pct[swift_type]:
             return True
         else:
             return False

--- a/test/test_ringmasterd.py
+++ b/test/test_ringmasterd.py
@@ -173,6 +173,17 @@ class test_ringmasterserver(unittest.TestCase):
         self.assertEquals(rmd.logger.debug.call_count, 4)
         self.assertEquals(rmd.logger.exception.call_count, 0)
         rmd.logger.reset_mock()
+        # test that container and obj are ok on missing a small pct
+        dsp_rpt_spct = dsp_rpt
+        dsp_rpt_spct['container']['pct_found'] = 99.9995
+        dsp_rpt_spct['object']['pct_found'] = 99.9995
+        popen.return_value.communicate.return_value = [json.dumps(dsp_rpt_spct)]
+        print json.dumps(dsp_rpt_spct)
+        self.assertTrue(rmd.dispersion_ok('container'))
+        self.assertTrue(rmd.dispersion_ok('object'))
+        self.assertEquals(rmd.logger.debug.call_count, 4)
+        self.assertEquals(rmd.logger.exception.call_count, 0)
+        rmd.logger.reset_mock()
         # test that container and obj fail on missing 2 replicas
         dsp_rpt_missing = dsp_rpt
         dsp_rpt_missing['container']['missing_2'] = 42
@@ -186,6 +197,8 @@ class test_ringmasterserver(unittest.TestCase):
         rmd.logger.reset_mock()
         # test that container and obj fail on missing large pct
         dsp_rpt_pct = dsp_rpt
+        dsp_rpt_pct['container']['missing_2'] = 0
+        dsp_rpt_pct['object']['missing_2'] = 0
         dsp_rpt_pct['container']['pct_found'] = 42.0
         dsp_rpt_pct['object']['pct_found'] = 42.0
         popen.return_value.communicate.return_value = [json.dumps(dsp_rpt_pct)]


### PR DESCRIPTION
Make sure we handle both the new dispersion report --json output (i.e.
where missing_X isn't present unless that many replicas are missing X
copies) as well as the older output.
