### PR TITLE
adding variable for the binary path that is found

### DIFF
--- a/etc/init.d/swift-ring-master-init
+++ b/etc/init.d/swift-ring-master-init
@@ -12,30 +12,31 @@
 ### END INIT INFO
 
 CONF="/etc/swift/ring-master.conf"
+DIRNAME=$(dirname `which swift-ring-master-server`)
 
 # Carry out specific functions when asked to by the system
 case "$1" in
     start)
         echo "Starting swift-ring-master"
-        /usr/bin/swift-ring-master-server start --conf=$CONF
+        $DIRNAME/swift-ring-master-server start --conf=$CONF
         ;;
     stop)
         echo "Stopping swift-ring-master"
-        /usr/bin/swift-ring-master-server stop --conf=$CONF
+        $DIRNAME/swift-ring-master-server stop --conf=$CONF
         ;;
     restart)
         echo "Restarting swift-ring-master"
-        /usr/bin/swift-ring-master-server stop --conf=$CONF
+        $DIRNAME/swift-ring-master-server stop --conf=$CONF
         sleep 1
-        /usr/bin/swift-ring-master-server start --conf=$CONF
+        $DIRNAME/swift-ring-master-server start --conf=$CONF
         ;;
     pause)
         echo "Pausing swift-ring-master"
-        /usr/bin/swift-ring-master-server pause --conf=$CONF
+        $DIRNAME/swift-ring-master-server pause --conf=$CONF
         ;;
     unpause)
         echo "Unpausing swift-ring-master"
-        /usr/bin/swift-ring-master-server unpause --conf=$CONF
+        $DIRNAME/swift-ring-master-server unpause --conf=$CONF
         ;;
     *)
         echo "Usage: /etc/init.d/swift-ring-master {start|stop|restart|pause|unpause}"

--- a/etc/init.d/swift-ring-master-wsgi-init
+++ b/etc/init.d/swift-ring-master-wsgi-init
@@ -12,21 +12,22 @@
 ### END INIT INFO
 
 CONF="/etc/swift/ring-master.conf"
+DIRNAME=$(dirname `which swift-ring-master-wsgi-server`)
 
 # Carry out specific functions when asked to by the system
 case "$1" in
     start)
         echo "Starting swift-ring-master-wsgi"
-        /usr/bin/swift-ring-master-wsgi-server start --conf=$CONF
+        $DIRNAME/swift-ring-master-wsgi-server start --conf=$CONF
         ;;
     stop)
         echo "Stopping swift-ring-master-wsgi"
-        /usr/bin/swift-ring-master-wsgi-server stop --conf=$CONF
+        $DIRNAME/swift-ring-master-wsgi-server stop --conf=$CONF
         ;;
     restart)
         echo "Restarting swift-ring-master-wsgi"
-        /usr/bin/swift-ring-master-wsgi-server stop --conf=$CONF
-        /usr/bin/swift-ring-master-wsgi-server start --conf=$CONF
+        $DIRNAME/swift-ring-master-wsgi-server stop --conf=$CONF
+        $DIRNAME/swift-ring-master-wsgi-server start --conf=$CONF
         ;;
     *)
         echo "Usage: /etc/init.d/swift-ring-master-wsgi {start|stop|restart}"

--- a/etc/init.d/swift-ring-minion
+++ b/etc/init.d/swift-ring-minion
@@ -12,21 +12,22 @@
 ### END INIT INFO
 
 CONF="/etc/swift/ring-minion.conf"
+DIRNAME=$(dirname `which swift-ring-minion-server`)
 
 # Carry out specific functions when asked to by the system
 case "$1" in
     start)
         echo "Starting swift-ring-minion"
-        /usr/bin/swift-ring-minion-server start --conf=$CONF
+        $DIRNAME/swift-ring-minion-server start --conf=$CONF
         ;;
     stop)
         echo "Stopping swift-ring-minion"
-        /usr/bin/swift-ring-minion-server stop --conf=$CONF
+        $DIRNAME/swift-ring-minion-server stop --conf=$CONF
         ;;
     restart)
         echo "Restarting swift-ring-minion"
-        /usr/bin/swift-ring-minion-server stop --conf=$CONF
-        /usr/bin/swift-ring-minion-server start --conf=$CONF
+        $DIRNAME/swift-ring-minion-server stop --conf=$CONF
+        $DIRNAME/swift-ring-minion-server start --conf=$CONF
         ;;
     *)
         echo "Usage: /etc/init.d/swift-ring-minion {start|stop|restart}"


### PR DESCRIPTION
using which and dirname to find the path where the binary actually resides
since one could chose to specify something other than /usr/bin for the python
install prefix
